### PR TITLE
Change @derive annotation params type to Any*

### DIFF
--- a/core/src/main/scala/org/manatki/derevo/package.scala
+++ b/core/src/main/scala/org/manatki/derevo/package.scala
@@ -5,7 +5,7 @@ import scala.annotation.{StaticAnnotation, compileTimeOnly}
 package derevo {
 
   @compileTimeOnly("enable macro paradise to expand macro annotations")
-  class derive(instances: InstanceDef*) extends StaticAnnotation {
+  class derive(instances: Any*) extends StaticAnnotation {
     def macroTransform(annottees: Any*): Any = macro Derevo.deriveMacro
   }
 


### PR DESCRIPTION
Removes highlighting problem for derivations with parameters. E.g. `@derive(decoder(snakeCase))` was highlighted, because `decoder.apply(...)` was returning `Decoder` but not `InstanceDef`