### PR TITLE
Add solution for #27

### DIFF
--- a/core/src/main/scala/derevo/Derevo.scala
+++ b/core/src/main/scala/derevo/Derevo.scala
@@ -124,7 +124,10 @@ class Derevo(val c: blackbox.Context) {
     val tn = TermName(name)
     if (cls.tparams.isEmpty) {
       val resT = mkAppliedType(toTc, tq"$typName")
-      q"implicit val $tn: $resT = $call"
+      q"""
+      @java.lang.SuppressWarnings(scala.Array("org.wartremover.warts.All", "scalafix:All", "all"))
+      implicit val $tn: $resT = $call
+      """
     } else {
       val tparams = cls.tparams.drop(drop)
       val implicits = tparams.flatMap { tparam =>
@@ -143,7 +146,10 @@ class Derevo(val c: blackbox.Context) {
       val tps    = tparams.map(_.name)
       val appTyp = tq"$typName[..$tps]"
       val resT   = mkAppliedType(toTc, appTyp)
-      q"implicit def $tn[..$tparams](implicit ..$implicits): $resT = $call"
+      q"""
+      @java.lang.SuppressWarnings(scala.Array("org.wartremover.warts.All", "scalafix:All", "all"))
+      implicit def $tn[..$tparams](implicit ..$implicits): $resT = $call
+      """
     }
   }
 


### PR DESCRIPTION
We should never validate macros-generated code.
For example WartRemover with `tethys` macros complains about Any, Var and null, in other cases i've seen asInstanceOf and isInstanceOf casts inside of macro. And there always will be ImplicitParameter and ImplicitConversion warnings, because WartRemover decided so.
 
For this reason i have decided to disable **ALL** Scalafix, WartRemover and Scapegoat checks on generated implicit definitions with the following @SupressWarnings values:
`org.wartremover.warts.All` - disables all WartRemover warnings
`scalafix:all` - disables all Scalafix warnings
`all` - disables all Scapegoat warnings