### PR TITLE
[WIP] Implement publishing on GitHub

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,0 +1,5 @@
+import sbt.settingKey
+
+object Publish {
+  val publishToGitHub = settingKey[Boolean]("Should artifact be published to GitHub packages or SonarType")
+}


### PR DESCRIPTION
Introducing 3 new `Env` vars:
`GITHUB_PUBLISH`: Boolean - Should publish on GitHub or SonarType
`GITHUB_USER`: String - User (not org!) publishing the artifacts
`GITHUB_TOKEN`: String - User token

Artifact version pattern for GitHub: `"${version}-${HEAD commit SHA1}-SNAPSHOT"`