### PR TITLE
universalEq derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ import cats.syntax.monoid._
 
 @derive(eqv, show, order, monoid)
 case class Foo(bar: String, baz: Int)
+@derive(eqv.universal)
+case class Bar(x: Int)
 
 assert(Foo("111", 222) === Foo("111", 222))
+assert(Bar(1) === Bar(1))
 assert(show"${Foo("111", 222)}" === "Foo{bar=111,baz=222}")
 assert((Foo("111", 222) compare Foo("222", 333)) == -1)
 assert((Foo("1", 1) |+| Foo("2", 2)) == Foo("12", 3))

--- a/cats/src/main/scala/derevo/cats/eq.scala
+++ b/cats/src/main/scala/derevo/cats/eq.scala
@@ -23,4 +23,8 @@ object eq extends Derivation[Eq] {
     }
 
   implicit def instance[T]: Eq[T] = macro Magnolia.gen[T]
+
+  object universal extends Derivation[Eq] {
+    implicit def instance[T]: Eq[T] = Eq.fromUniversalEquals[T]
+  }
 }

--- a/cats/src/test/scala/derevo/cats/EqSpec.scala
+++ b/cats/src/test/scala/derevo/cats/EqSpec.scala
@@ -1,0 +1,31 @@
+package derevo.cats
+
+import cats.Eq
+import derevo.cats.{eq => eqv}
+import derevo.derive
+import org.scalatest.freespec.AnyFreeSpec
+
+class EqSpec extends AnyFreeSpec {
+
+  "Cats Eq derivation" - {
+    "should derive eq instances" - {
+      "through magnolia" in {
+        import cats.instances.int._
+
+        @derive(eqv)
+        case class Qux(a: Int)
+
+        assert(Eq[Qux].eqv(Qux(1), Qux(1)))
+        assert(Eq[Qux].neqv(Qux(1), Qux(-1)))
+      }
+
+      "through Eq.fromUniversalEquals" in {
+        @derive(eqv.universal)
+        case class Qux(a: Int)
+
+        assert(Eq[Qux].eqv(Qux(1), Qux(1)))
+        assert(Eq[Qux].neqv(Qux(1), Qux(-1)))
+      }
+    }
+  }
+}

--- a/intellijIntegration/src/main/scala/derevo/intellij/DerevoDeriveInjector.scala
+++ b/intellijIntegration/src/main/scala/derevo/intellij/DerevoDeriveInjector.scala
@@ -34,11 +34,12 @@ object DerevoDeriveInjector {
   private[this] val pkg              = "_root_.derevo"
   private[this] val mapping = Map[String, String](
     // Cats Core
-    s"$pkg.cats.show.type"      -> "implicit val derevoDeriveCatsShow: _root_.cats.Show[%s] = ???",
-    s"$pkg.cats.semigroup.type" -> "implicit val derevoDeriveCatsSemigroup: _root_.cats.Semigroup[%s] = ???",
-    s"$pkg.cats.monoid.type"    -> "implicit val derevoDeriveCatsMonoid: _root_.cats.Monoid[%s] = ???",
-    s"$pkg.cats.eq.type"        -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
-    s"$pkg.cats.order.type"     -> "implicit val derevoDeriveCatsOrder: _root_.cats.Order[%s] = ???",
+    s"$pkg.cats.show.type"         -> "implicit val derevoDeriveCatsShow: _root_.cats.Show[%s] = ???",
+    s"$pkg.cats.semigroup.type"    -> "implicit val derevoDeriveCatsSemigroup: _root_.cats.Semigroup[%s] = ???",
+    s"$pkg.cats.monoid.type"       -> "implicit val derevoDeriveCatsMonoid: _root_.cats.Monoid[%s] = ???",
+    s"$pkg.cats.eq.type"           -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
+    s"$pkg.cats.eq.universal.type" -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
+    s"$pkg.cats.order.type"        -> "implicit val derevoDeriveCatsOrder: _root_.cats.Order[%s] = ???",
     // Cats Tagless
     s"$pkg.tagless.functor.type"       -> "implicit val derevoDeriveCatsFunctor: _root_.cats.Functor[%s] = ???",
     s"$pkg.tagless.flatMap.type"       -> "implicit val derevoDeriveCatsFlatMap: _root_.cats.FlatMap[%s] = ???",
@@ -91,11 +92,12 @@ object DerevoDeriveInjector {
   private[this] val oldPkg              = "_root_.org.manatki.derevo"
   private[this] val oldMapping = Map[String, String](
     // Cats
-    s"$oldPkg.catsInstances.show.type"      -> "implicit val derevoDeriveCatsShow: _root_.cats.Show[%s] = ???",
-    s"$oldPkg.catsInstances.semigroup.type" -> "implicit val derevoDeriveCatsSemigroup: _root_.cats.Semigroup[%s] = ???",
-    s"$oldPkg.catsInstances.monoid.type"    -> "implicit val derevoDeriveCatsMonoid: _root_.cats.Monoid[%s] = ???",
-    s"$oldPkg.catsInstances.eq.type"        -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
-    s"$oldPkg.catsInstances.order.type"     -> "implicit val derevoDeriveCatsOrder: _root_.cats.Order[%s] = ???",
+    s"$oldPkg.catsInstances.show.type"         -> "implicit val derevoDeriveCatsShow: _root_.cats.Show[%s] = ???",
+    s"$oldPkg.catsInstances.semigroup.type"    -> "implicit val derevoDeriveCatsSemigroup: _root_.cats.Semigroup[%s] = ???",
+    s"$oldPkg.catsInstances.monoid.type"       -> "implicit val derevoDeriveCatsMonoid: _root_.cats.Monoid[%s] = ???",
+    s"$oldPkg.catsInstances.eq.type"           -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
+    s"$oldPkg.catsInstances.eq.universal.type" -> "implicit val derevoDeriveCatsEq: _root_.cats.Eq[%s] = ???",
+    s"$oldPkg.catsInstances.order.type"        -> "implicit val derevoDeriveCatsOrder: _root_.cats.Order[%s] = ???",
     // Cats Tagless
     s"$oldPkg.tagless.functor.type"       -> "implicit val derevoDeriveCatsFunctor: _root_.cats.Functor[%s] = ???",
     s"$oldPkg.tagless.flatMap.type"       -> "implicit val derevoDeriveCatsFlatMap: _root_.cats.FlatMap[%s] = ???",


### PR DESCRIPTION
Added derivation for `cats.Eq` through `Eq.fromUniversalEquals`. It could be useful for cases when `equals` implementation is good enough.

I tried to embed it in the `cats.derevo.eq`, but I didn't find a way to make conditional derivation. For my case I imagined something like this:
```scala
@derive(cats.derevo.eq(universal = false) // default, through magnolia
case class Foo(a: Int)

@derive(cats.derevo.eq(universal = true) // through Eq.fromUniversalEquals
case class Bar(a: Int)
```